### PR TITLE
Question selection page (Home)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -7,6 +7,7 @@ from fastapi.staticfiles import StaticFiles
 
 from database import init_db
 from seed_questions import seed
+from routers import questions
 
 RECORDINGS_DIR = os.path.join(os.path.dirname(__file__), "..", "data", "recordings")
 os.makedirs(RECORDINGS_DIR, exist_ok=True)
@@ -28,6 +29,8 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+app.include_router(questions.router, prefix="/api")
 
 app.mount("/recordings", StaticFiles(directory=RECORDINGS_DIR), name="recordings")
 

--- a/backend/routers/questions.py
+++ b/backend/routers/questions.py
@@ -1,0 +1,24 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from database import get_db, Question
+from models import QuestionOut
+
+router = APIRouter()
+
+
+@router.get("/questions", response_model=list[QuestionOut])
+def list_questions(db: Session = Depends(get_db)):
+    questions = db.query(Question).all()
+    result = []
+    for q in questions:
+        result.append(
+            QuestionOut(
+                id=q.id,
+                category=q.category,
+                question_text=q.question_text,
+                tips=q.tips,
+                attempt_count=len(q.attempts),
+            )
+        )
+    return result

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,4 +1,5 @@
 import { Routes, Route } from 'react-router-dom'
+import Home from './pages/Home'
 
 function Placeholder({ name }) {
   return (
@@ -12,7 +13,7 @@ export default function App() {
   return (
     <div className="min-h-screen bg-gray-950 text-white">
       <Routes>
-        <Route path="/" element={<Placeholder name="Home" />} />
+        <Route path="/" element={<Home />} />
         <Route path="/interview/:questionId" element={<Placeholder name="Interview" />} />
         <Route path="/review/:questionId" element={<Placeholder name="Review" />} />
       </Routes>

--- a/frontend/src/components/QuestionCard.jsx
+++ b/frontend/src/components/QuestionCard.jsx
@@ -1,0 +1,58 @@
+import { useNavigate } from 'react-router-dom'
+
+const CATEGORY_COLORS = {
+  Conflict: 'bg-red-600',
+  Learning: 'bg-blue-600',
+  Failure: 'bg-orange-600',
+  Leadership: 'bg-purple-600',
+  Technical: 'bg-emerald-600',
+  'Trade-offs': 'bg-yellow-600',
+  Growth: 'bg-teal-600',
+  Impact: 'bg-indigo-600',
+}
+
+export default function QuestionCard({ question }) {
+  const navigate = useNavigate()
+  const tagColor = CATEGORY_COLORS[question.category] || 'bg-gray-600'
+
+  return (
+    <div
+      className="bg-gray-800 rounded-xl p-6 cursor-pointer hover:bg-gray-700 transition-colors border border-gray-700 hover:border-gray-500"
+      onClick={() => navigate(`/interview/${question.id}`)}
+    >
+      <div className="flex items-center justify-between mb-3">
+        <span className={`${tagColor} text-white text-xs font-semibold px-3 py-1 rounded-full`}>
+          {question.category}
+        </span>
+        {question.attempt_count > 0 && (
+          <span className="bg-gray-600 text-gray-200 text-xs px-2 py-1 rounded-full">
+            {question.attempt_count} attempt{question.attempt_count !== 1 ? 's' : ''}
+          </span>
+        )}
+      </div>
+      <p className="text-gray-100 text-sm leading-relaxed">{question.question_text}</p>
+      <div className="mt-4 flex justify-between items-center">
+        <button
+          className="text-blue-400 text-sm hover:text-blue-300 transition-colors"
+          onClick={(e) => {
+            e.stopPropagation()
+            navigate(`/interview/${question.id}`)
+          }}
+        >
+          Practice
+        </button>
+        {question.attempt_count > 0 && (
+          <button
+            className="text-gray-400 text-sm hover:text-gray-300 transition-colors"
+            onClick={(e) => {
+              e.stopPropagation()
+              navigate(`/review/${question.id}`)
+            }}
+          >
+            Review
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -1,0 +1,37 @@
+import { useState, useEffect } from 'react'
+import { fetchQuestions } from '../api/client'
+import QuestionCard from '../components/QuestionCard'
+
+export default function Home() {
+  const [questions, setQuestions] = useState([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    fetchQuestions()
+      .then(setQuestions)
+      .catch(console.error)
+      .finally(() => setLoading(false))
+  }, [])
+
+  return (
+    <div className="max-w-5xl mx-auto px-6 py-10">
+      <div className="mb-10">
+        <h1 className="text-3xl font-bold">STAR Coach</h1>
+        <p className="text-gray-400 mt-2">
+          Practice behavioral interview questions and get AI coaching feedback.
+          Select a question to start practicing.
+        </p>
+      </div>
+
+      {loading ? (
+        <div className="text-gray-400 text-center py-20">Loading questions...</div>
+      ) : (
+        <div className="grid gap-4 sm:grid-cols-2">
+          {questions.map((q) => (
+            <QuestionCard key={q.id} question={q} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Questions API router returning all questions with attempt counts
- Home page with grid of QuestionCard components
- Category color-coded tags and attempt count badges
- Click to navigate to interview or review pages

## Test plan
- [x] Frontend builds cleanly
- [ ] Home page renders 8 question cards from API
- [ ] Clicking a card navigates to /interview/:id

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)