### PR TITLE
Review page — past attempts & feedback

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -7,7 +7,7 @@ from fastapi.staticfiles import StaticFiles
 
 from database import init_db
 from seed_questions import seed
-from routers import questions, recordings, analysis
+from routers import questions, recordings, analysis, attempts
 
 RECORDINGS_DIR = os.path.join(os.path.dirname(__file__), "..", "data", "recordings")
 os.makedirs(RECORDINGS_DIR, exist_ok=True)
@@ -33,6 +33,7 @@ app.add_middleware(
 app.include_router(questions.router, prefix="/api")
 app.include_router(recordings.router, prefix="/api")
 app.include_router(analysis.router, prefix="/api")
+app.include_router(attempts.router, prefix="/api")
 
 app.mount("/recordings", StaticFiles(directory=RECORDINGS_DIR), name="recordings")
 

--- a/backend/routers/attempts.py
+++ b/backend/routers/attempts.py
@@ -1,0 +1,39 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from database import get_db, Attempt, Question
+from models import AttemptDetailOut, AttemptOut, TranscriptionOut, FeedbackOut, AnalyticsOut
+
+router = APIRouter()
+
+
+@router.get("/attempts/{question_id}")
+def list_attempts(question_id: int, db: Session = Depends(get_db)):
+    question = db.get(Question, question_id)
+    if not question:
+        raise HTTPException(status_code=404, detail="Question not found")
+
+    attempts = (
+        db.query(Attempt)
+        .filter(Attempt.question_id == question_id)
+        .order_by(Attempt.attempt_number.desc())
+        .all()
+    )
+
+    results = []
+    for a in attempts:
+        detail = AttemptDetailOut(
+            attempt=AttemptOut.model_validate(a),
+            transcription=(
+                TranscriptionOut.model_validate(a.transcription) if a.transcription else None
+            ),
+            feedback=(
+                FeedbackOut.model_validate(a.feedback) if a.feedback else None
+            ),
+            analytics=(
+                AnalyticsOut.model_validate(a.analytics) if a.analytics else None
+            ),
+        )
+        results.append(detail)
+
+    return results

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,14 +1,7 @@
 import { Routes, Route } from 'react-router-dom'
 import Home from './pages/Home'
 import Interview from './pages/Interview'
-
-function Placeholder({ name }) {
-  return (
-    <div className="flex items-center justify-center h-screen text-gray-400">
-      {name} — coming soon
-    </div>
-  )
-}
+import Review from './pages/Review'
 
 export default function App() {
   return (
@@ -16,7 +9,7 @@ export default function App() {
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/interview/:questionId" element={<Interview />} />
-        <Route path="/review/:questionId" element={<Placeholder name="Review" />} />
+        <Route path="/review/:questionId" element={<Review />} />
       </Routes>
     </div>
   )

--- a/frontend/src/components/AttemptList.jsx
+++ b/frontend/src/components/AttemptList.jsx
@@ -1,0 +1,50 @@
+export default function AttemptList({ attempts, selectedId, onSelect }) {
+  if (!attempts || attempts.length === 0) {
+    return (
+      <div className="bg-gray-800 rounded-xl p-6">
+        <h3 className="text-lg font-semibold mb-3">Attempts</h3>
+        <p className="text-gray-400 text-sm">No attempts yet.</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="bg-gray-800 rounded-xl p-6">
+      <h3 className="text-lg font-semibold mb-3">Attempts</h3>
+      <div className="space-y-2">
+        {attempts.map((item) => {
+          const a = item.attempt
+          const isSelected = a.id === selectedId
+          const hasAnalysis = !!item.feedback
+
+          return (
+            <button
+              key={a.id}
+              onClick={() => onSelect(a.id)}
+              className={`w-full text-left p-3 rounded-lg transition-colors ${
+                isSelected ? 'bg-blue-600/30 border border-blue-500' : 'bg-gray-700 hover:bg-gray-600 border border-transparent'
+              }`}
+            >
+              <div className="flex items-center justify-between">
+                <span className="text-sm font-medium">Attempt #{a.attempt_number}</span>
+                <span className="text-xs text-gray-400">
+                  {a.created_at ? new Date(a.created_at).toLocaleDateString() : ''}
+                </span>
+              </div>
+              <div className="flex items-center gap-2 mt-1">
+                <span className="text-xs text-gray-400">
+                  {a.duration_seconds ? `${Math.round(a.duration_seconds)}s` : ''}
+                </span>
+                {hasAnalysis ? (
+                  <span className="text-xs text-green-400">Analyzed</span>
+                ) : (
+                  <span className="text-xs text-yellow-400">Pending</span>
+                )}
+              </div>
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/Review.jsx
+++ b/frontend/src/pages/Review.jsx
@@ -1,0 +1,139 @@
+import { useState, useEffect, useRef } from 'react'
+import { useParams, useNavigate } from 'react-router-dom'
+import { getAttempts, getAnalysisStatus, fetchQuestions } from '../api/client'
+import AttemptList from '../components/AttemptList'
+import TranscriptView from '../components/TranscriptView'
+import FeedbackPanel from '../components/FeedbackPanel'
+import AnalyticsCard from '../components/AnalyticsCard'
+
+export default function Review() {
+  const { questionId } = useParams()
+  const navigate = useNavigate()
+  const [question, setQuestion] = useState(null)
+  const [attempts, setAttempts] = useState([])
+  const [selectedId, setSelectedId] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const attemptsRef = useRef(attempts)
+
+  useEffect(() => {
+    attemptsRef.current = attempts
+  }, [attempts])
+
+  useEffect(() => {
+    Promise.all([
+      fetchQuestions(),
+      getAttempts(questionId),
+    ])
+      .then(([qs, atts]) => {
+        const q = qs.find((q) => q.id === Number(questionId))
+        setQuestion(q)
+        setAttempts(atts)
+        if (atts.length > 0) {
+          setSelectedId(atts[0].attempt.id)
+        }
+      })
+      .catch(console.error)
+      .finally(() => setLoading(false))
+  }, [questionId])
+
+  // Poll for analysis status on the selected attempt if it's pending
+  useEffect(() => {
+    if (!selectedId) return
+
+    const selected = attemptsRef.current.find((a) => a.attempt.id === selectedId)
+    if (selected?.feedback) return // already complete
+
+    const interval = setInterval(async () => {
+      try {
+        const status = await getAnalysisStatus(selectedId)
+        if (status.status === 'complete') {
+          const atts = await getAttempts(questionId)
+          setAttempts(atts)
+          clearInterval(interval)
+        }
+      } catch {
+        // ignore polling errors
+      }
+    }, 3000)
+
+    return () => clearInterval(interval)
+  }, [selectedId, questionId])
+
+  const selected = attempts.find((a) => a.attempt.id === selectedId)
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-screen text-gray-400">
+        Loading...
+      </div>
+    )
+  }
+
+  return (
+    <div className="max-w-6xl mx-auto px-6 py-8">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <button
+            onClick={() => navigate('/')}
+            className="text-gray-400 hover:text-white text-sm mb-2 transition-colors"
+          >
+            &larr; Back to questions
+          </button>
+          <h1 className="text-xl font-bold">{question?.question_text}</h1>
+        </div>
+        <button
+          onClick={() => navigate(`/interview/${questionId}`)}
+          className="bg-blue-600 hover:bg-blue-500 text-white px-4 py-2 rounded-lg text-sm transition-colors"
+        >
+          Practice Again
+        </button>
+      </div>
+
+      <div className="grid grid-cols-12 gap-6">
+        {/* Left sidebar: attempt list */}
+        <div className="col-span-3">
+          <AttemptList
+            attempts={attempts}
+            selectedId={selectedId}
+            onSelect={setSelectedId}
+          />
+        </div>
+
+        {/* Main content */}
+        <div className="col-span-9 space-y-6">
+          {selected ? (
+            <>
+              {/* Video playback */}
+              <div className="bg-gray-800 rounded-xl p-6">
+                <h3 className="text-lg font-semibold mb-3">Recording</h3>
+                <video
+                  src={`/recordings/${selected.attempt.video_path}`}
+                  controls
+                  className="w-full rounded-lg max-h-96"
+                />
+              </div>
+
+              <div className="grid grid-cols-2 gap-6">
+                <TranscriptView transcription={selected.transcription} />
+                <AnalyticsCard analytics={selected.analytics} />
+              </div>
+
+              <FeedbackPanel feedback={selected.feedback} />
+
+              {!selected.feedback && (
+                <div className="bg-yellow-900/30 border border-yellow-700 rounded-xl p-4 text-sm text-yellow-300">
+                  Analysis is in progress. This page will update automatically when complete.
+                </div>
+              )}
+            </>
+          ) : (
+            <div className="text-gray-400 text-center py-20">
+              Select an attempt to view details.
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Attempts router returning full attempt details (transcript + analytics + feedback)
- Review page: attempt list sidebar, video playback, transcript, analytics, coaching feedback
- Auto-polling for pending analysis results (3s interval)
- Polling uses ref to avoid re-render loops

## Test plan
- [x] Frontend builds cleanly
- [ ] Review page lists all attempts for a question
- [ ] Clicking an attempt shows video + transcript + analytics + feedback
- [ ] Pending analysis auto-refreshes when complete

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)