### PR TITLE
feat: add dashboard with stats, streak calendar, and quote

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -7,7 +7,7 @@ from fastapi.staticfiles import StaticFiles
 
 from database import init_db
 from seed_questions import seed
-from routers import questions, recordings, analysis, attempts
+from routers import questions, recordings, analysis, attempts, dashboard
 
 RECORDINGS_DIR = os.path.join(os.path.dirname(__file__), "..", "data", "recordings")
 os.makedirs(RECORDINGS_DIR, exist_ok=True)
@@ -34,6 +34,7 @@ app.include_router(questions.router, prefix="/api")
 app.include_router(recordings.router, prefix="/api")
 app.include_router(analysis.router, prefix="/api")
 app.include_router(attempts.router, prefix="/api")
+app.include_router(dashboard.router, prefix="/api")
 
 app.mount("/recordings", StaticFiles(directory=RECORDINGS_DIR), name="recordings")
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -83,3 +83,14 @@ class ProgressOut(BaseModel):
     question_text: str
     trend: str  # "improving", "steady", "declining"
     data_points: list[ProgressPoint]
+
+
+class DashboardOut(BaseModel):
+    total_attempts: int
+    questions_practiced: int
+    total_questions: int
+    total_practice_time: float
+    avg_clarity: float | None = None
+    avg_confidence: float | None = None
+    avg_structure: float | None = None
+    activity: dict[str, int]

--- a/backend/routers/dashboard.py
+++ b/backend/routers/dashboard.py
@@ -1,0 +1,53 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy import func as sa_func
+from sqlalchemy.orm import Session
+
+from database import get_db, Attempt, Analytics, Feedback, Question
+
+router = APIRouter()
+
+
+@router.get("/dashboard")
+def get_dashboard(db: Session = Depends(get_db)):
+    total_attempts = db.query(sa_func.count(Attempt.id)).scalar() or 0
+    questions_practiced = (
+        db.query(sa_func.count(sa_func.distinct(Attempt.question_id))).scalar() or 0
+    )
+    total_questions = db.query(sa_func.count(Question.id)).scalar() or 0
+    total_practice_time = (
+        db.query(sa_func.coalesce(sa_func.sum(Attempt.duration_seconds), 0)).scalar()
+    )
+
+    # Average scores across all analytics
+    avg_scores = db.query(
+        sa_func.avg(Analytics.clarity_score),
+        sa_func.avg(Analytics.confidence_score),
+        sa_func.avg(Analytics.structure_score),
+    ).first()
+    avg_clarity = round(avg_scores[0], 1) if avg_scores[0] is not None else None
+    avg_confidence = round(avg_scores[1], 1) if avg_scores[1] is not None else None
+    avg_structure = round(avg_scores[2], 1) if avg_scores[2] is not None else None
+
+    # Daily activity: count of attempts per date for streak calendar
+    # created_at is stored as text from func.now(), format: YYYY-MM-DD HH:MM:SS
+    daily_activity = (
+        db.query(
+            sa_func.date(Attempt.created_at).label("date"),
+            sa_func.count(Attempt.id).label("count"),
+        )
+        .group_by(sa_func.date(Attempt.created_at))
+        .order_by(sa_func.date(Attempt.created_at))
+        .all()
+    )
+    activity = {str(row.date): row.count for row in daily_activity if row.date}
+
+    return {
+        "total_attempts": total_attempts,
+        "questions_practiced": questions_practiced,
+        "total_questions": total_questions,
+        "total_practice_time": total_practice_time,
+        "avg_clarity": avg_clarity,
+        "avg_confidence": avg_confidence,
+        "avg_structure": avg_structure,
+        "activity": activity,
+    }

--- a/backend/routers/dashboard.py
+++ b/backend/routers/dashboard.py
@@ -2,12 +2,13 @@ from fastapi import APIRouter, Depends
 from sqlalchemy import func as sa_func
 from sqlalchemy.orm import Session
 
-from database import get_db, Attempt, Analytics, Feedback, Question
+from database import get_db, Attempt, Analytics, Question
+from models import DashboardOut
 
 router = APIRouter()
 
 
-@router.get("/dashboard")
+@router.get("/dashboard", response_model=DashboardOut)
 def get_dashboard(db: Session = Depends(get_db)):
     total_attempts = db.query(sa_func.count(Attempt.id)).scalar() or 0
     questions_practiced = (

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -36,4 +36,9 @@ export async function getProgress(questionId) {
   return data
 }
 
+export async function fetchDashboard() {
+  const { data } = await api.get('/dashboard')
+  return data
+}
+
 export default api

--- a/frontend/src/components/Dashboard.jsx
+++ b/frontend/src/components/Dashboard.jsx
@@ -23,7 +23,7 @@ function StreakCalendar({ activity }) {
     for (let i = 139; i >= 0; i--) {
       const d = new Date(today)
       d.setDate(d.getDate() - i)
-      const key = d.toISOString().split('T')[0]
+      const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
       days.push({ date: key, count: activity[key] || 0, day: d.getDay() })
     }
 
@@ -69,7 +69,7 @@ function StreakCalendar({ activity }) {
   return (
     <div className="overflow-x-auto">
       <div className="inline-block">
-        <div className="flex gap-0.5 mb-1 ml-8 text-[10px] text-gray-500">
+        <div className="flex gap-1 mb-1 ml-8 text-[10px] text-gray-500">
           {weeks.map((_, i) => {
             const month = months.find((m) => m.index === i)
             return (
@@ -81,12 +81,12 @@ function StreakCalendar({ activity }) {
         </div>
         <div className="flex gap-1">
           <div className="flex flex-col gap-0.5 text-[10px] text-gray-500 mr-1">
+            <div className="h-3"></div>
             <div className="h-3">Mon</div>
             <div className="h-3"></div>
             <div className="h-3">Wed</div>
             <div className="h-3"></div>
             <div className="h-3">Fri</div>
-            <div className="h-3"></div>
             <div className="h-3"></div>
           </div>
           {weeks.map((week, wi) => (
@@ -155,7 +155,7 @@ export default function Dashboard({ data }) {
       {/* Quote */}
       <div className="bg-gray-800/50 rounded-xl p-6 border border-gray-700/50">
         <blockquote className="text-gray-300 text-lg italic leading-relaxed">
-          "{QUOTE.text}"
+          {"\u201C"}{QUOTE.text}{"\u201D"}
         </blockquote>
         <p className="text-gray-500 text-sm mt-2">— {QUOTE.author}</p>
       </div>

--- a/frontend/src/components/Dashboard.jsx
+++ b/frontend/src/components/Dashboard.jsx
@@ -1,0 +1,217 @@
+import { useMemo } from 'react'
+
+const QUOTE = {
+  text: 'You get rewarded in public for what you practice for years in private.',
+  author: 'Tony Robbins',
+}
+
+function formatTime(seconds) {
+  if (seconds < 60) return `${Math.round(seconds)}s`
+  const mins = Math.floor(seconds / 60)
+  if (mins < 60) return `${mins}m`
+  const hrs = Math.floor(mins / 60)
+  const remainMins = mins % 60
+  return remainMins > 0 ? `${hrs}h ${remainMins}m` : `${hrs}h`
+}
+
+function StreakCalendar({ activity }) {
+  const { weeks, months } = useMemo(() => {
+    const today = new Date()
+    const days = []
+
+    // 20 weeks of history (140 days)
+    for (let i = 139; i >= 0; i--) {
+      const d = new Date(today)
+      d.setDate(d.getDate() - i)
+      const key = d.toISOString().split('T')[0]
+      days.push({ date: key, count: activity[key] || 0, day: d.getDay() })
+    }
+
+    // Group into weeks (columns), starting from Sunday
+    const weeks = []
+    let currentWeek = new Array(days[0].day).fill(null)
+    for (const day of days) {
+      currentWeek.push(day)
+      if (currentWeek.length === 7) {
+        weeks.push(currentWeek)
+        currentWeek = []
+      }
+    }
+    if (currentWeek.length > 0) {
+      weeks.push(currentWeek)
+    }
+
+    // Month labels
+    const months = []
+    let lastMonth = null
+    weeks.forEach((week, i) => {
+      const firstDay = week.find((d) => d !== null)
+      if (firstDay) {
+        const month = new Date(firstDay.date).getMonth()
+        if (month !== lastMonth) {
+          months.push({ index: i, label: new Date(firstDay.date).toLocaleString('default', { month: 'short' }) })
+          lastMonth = month
+        }
+      }
+    })
+
+    return { weeks, months }
+  }, [activity])
+
+  const getColor = (count) => {
+    if (count === 0) return 'bg-gray-800'
+    if (count === 1) return 'bg-emerald-900'
+    if (count === 2) return 'bg-emerald-700'
+    if (count <= 4) return 'bg-emerald-500'
+    return 'bg-emerald-400'
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <div className="inline-block">
+        <div className="flex gap-0.5 mb-1 ml-8 text-[10px] text-gray-500">
+          {weeks.map((_, i) => {
+            const month = months.find((m) => m.index === i)
+            return (
+              <div key={i} className="w-3" style={{ minWidth: 12 }}>
+                {month ? month.label : ''}
+              </div>
+            )
+          })}
+        </div>
+        <div className="flex gap-1">
+          <div className="flex flex-col gap-0.5 text-[10px] text-gray-500 mr-1">
+            <div className="h-3">Mon</div>
+            <div className="h-3"></div>
+            <div className="h-3">Wed</div>
+            <div className="h-3"></div>
+            <div className="h-3">Fri</div>
+            <div className="h-3"></div>
+            <div className="h-3"></div>
+          </div>
+          {weeks.map((week, wi) => (
+            <div key={wi} className="flex flex-col gap-0.5">
+              {week.map((day, di) =>
+                day === null ? (
+                  <div key={di} className="w-3 h-3" />
+                ) : (
+                  <div
+                    key={di}
+                    className={`w-3 h-3 rounded-sm ${getColor(day.count)}`}
+                    title={`${day.date}: ${day.count} session${day.count !== 1 ? 's' : ''}`}
+                  />
+                )
+              )}
+            </div>
+          ))}
+        </div>
+        <div className="flex items-center gap-1 mt-2 text-[10px] text-gray-500 justify-end">
+          <span>Less</span>
+          <div className="w-3 h-3 rounded-sm bg-gray-800" />
+          <div className="w-3 h-3 rounded-sm bg-emerald-900" />
+          <div className="w-3 h-3 rounded-sm bg-emerald-700" />
+          <div className="w-3 h-3 rounded-sm bg-emerald-500" />
+          <div className="w-3 h-3 rounded-sm bg-emerald-400" />
+          <span>More</span>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function StatCard({ label, value, sub }) {
+  return (
+    <div className="bg-gray-800 rounded-xl p-5 border border-gray-700">
+      <p className="text-gray-400 text-xs uppercase tracking-wider mb-1">{label}</p>
+      <p className="text-2xl font-bold text-white">{value}</p>
+      {sub && <p className="text-gray-500 text-xs mt-1">{sub}</p>}
+    </div>
+  )
+}
+
+function ScoreBar({ label, score }) {
+  if (score === null || score === undefined) return null
+  const pct = (score / 5) * 100
+  return (
+    <div className="flex items-center gap-3">
+      <span className="text-gray-400 text-xs w-24">{label}</span>
+      <div className="flex-1 bg-gray-700 rounded-full h-2">
+        <div
+          className="bg-blue-500 h-2 rounded-full transition-all"
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <span className="text-gray-300 text-xs w-8 text-right">{score}/5</span>
+    </div>
+  )
+}
+
+export default function Dashboard({ data }) {
+  const hasStats = data.total_attempts > 0
+  const hasScores = data.avg_clarity !== null
+
+  return (
+    <div className="mb-10 space-y-6">
+      {/* Quote */}
+      <div className="bg-gray-800/50 rounded-xl p-6 border border-gray-700/50">
+        <blockquote className="text-gray-300 text-lg italic leading-relaxed">
+          "{QUOTE.text}"
+        </blockquote>
+        <p className="text-gray-500 text-sm mt-2">— {QUOTE.author}</p>
+      </div>
+
+      {!hasStats ? (
+        <div className="bg-gray-800/30 rounded-xl p-8 border border-gray-700/30 text-center">
+          <p className="text-gray-400 text-lg mb-2">No practice sessions yet</p>
+          <p className="text-gray-500 text-sm">
+            Pick a question below to start your first practice round.
+          </p>
+        </div>
+      ) : (
+        <>
+          {/* Stats cards */}
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+            <StatCard
+              label="Sessions"
+              value={data.total_attempts}
+            />
+            <StatCard
+              label="Questions"
+              value={`${data.questions_practiced}/${data.total_questions}`}
+              sub="practiced"
+            />
+            <StatCard
+              label="Practice Time"
+              value={formatTime(data.total_practice_time)}
+            />
+            <StatCard
+              label="Avg Score"
+              value={
+                hasScores
+                  ? (((data.avg_clarity + data.avg_confidence + data.avg_structure) / 3).toFixed(1))
+                  : '—'
+              }
+              sub={hasScores ? 'out of 5' : 'pending'}
+            />
+          </div>
+
+          {/* Average scores breakdown */}
+          {hasScores && (
+            <div className="bg-gray-800 rounded-xl p-5 border border-gray-700 space-y-3">
+              <p className="text-gray-400 text-xs uppercase tracking-wider mb-2">Average Scores</p>
+              <ScoreBar label="Clarity" score={data.avg_clarity} />
+              <ScoreBar label="Confidence" score={data.avg_confidence} />
+              <ScoreBar label="Structure" score={data.avg_structure} />
+            </div>
+          )}
+
+          {/* Streak calendar */}
+          <div className="bg-gray-800 rounded-xl p-5 border border-gray-700">
+            <p className="text-gray-400 text-xs uppercase tracking-wider mb-3">Practice Activity</p>
+            <StreakCalendar activity={data.activity} />
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -1,14 +1,19 @@
 import { useState, useEffect } from 'react'
-import { fetchQuestions } from '../api/client'
+import { fetchQuestions, fetchDashboard } from '../api/client'
 import QuestionCard from '../components/QuestionCard'
+import Dashboard from '../components/Dashboard'
 
 export default function Home() {
   const [questions, setQuestions] = useState([])
+  const [dashboardData, setDashboardData] = useState(null)
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
-    fetchQuestions()
-      .then(setQuestions)
+    Promise.all([fetchQuestions(), fetchDashboard()])
+      .then(([q, d]) => {
+        setQuestions(q)
+        setDashboardData(d)
+      })
       .catch(console.error)
       .finally(() => setLoading(false))
   }, [])
@@ -19,18 +24,22 @@ export default function Home() {
         <h1 className="text-3xl font-bold">STAR Coach</h1>
         <p className="text-gray-400 mt-2">
           Practice behavioral interview questions and get AI coaching feedback.
-          Select a question to start practicing.
         </p>
       </div>
 
       {loading ? (
-        <div className="text-gray-400 text-center py-20">Loading questions...</div>
+        <div className="text-gray-400 text-center py-20">Loading...</div>
       ) : (
-        <div className="grid gap-4 sm:grid-cols-2">
-          {questions.map((q) => (
-            <QuestionCard key={q.id} question={q} />
-          ))}
-        </div>
+        <>
+          {dashboardData && <Dashboard data={dashboardData} />}
+
+          <h2 className="text-xl font-semibold mb-4 text-gray-200">Practice Questions</h2>
+          <div className="grid gap-4 sm:grid-cols-2">
+            {questions.map((q) => (
+              <QuestionCard key={q.id} question={q} />
+            ))}
+          </div>
+        </>
       )}
     </div>
   )


### PR DESCRIPTION
## Summary
- Add a dashboard section to the landing page with a motivational Tony Robbins quote, summary stat cards (sessions, questions practiced, practice time, average score), average score breakdowns, and a GitHub-style streak/activity calendar
- Add a new `/api/dashboard` backend endpoint that aggregates practice stats and daily activity data
- Handle empty state gracefully when no practice sessions exist yet
- Questions list is preserved below the dashboard

## Changes
- **`backend/routers/dashboard.py`** — New FastAPI router with `/dashboard` endpoint returning aggregated stats
- **`backend/main.py`** — Register the dashboard router
- **`frontend/src/components/Dashboard.jsx`** — New component with quote, stat cards, score bars, and streak calendar
- **`frontend/src/api/client.js`** — Add `fetchDashboard()` API function
- **`frontend/src/pages/Home.jsx`** — Integrate Dashboard component above questions grid

## Test plan
- [ ] Verify dashboard loads with stats when practice sessions exist
- [ ] Verify empty state message shows when no sessions exist
- [ ] Verify streak calendar renders correctly with activity data
- [ ] Verify questions list still displays below dashboard
- [ ] Verify backend `/api/dashboard` endpoint returns correct aggregated data

🤖 Generated with [Claude Code](https://claude.com/claude-code)